### PR TITLE
Bringing in patch for json_transform_dict_array

### DIFF
--- a/src/busctl/busctl.c
+++ b/src/busctl/busctl.c
@@ -1732,11 +1732,14 @@ static int json_transform_variant(sd_bus_message *m, const char *contents, JsonV
 }
 
 static int json_transform_dict_array(sd_bus_message *m, JsonVariant **ret) {
-        _cleanup_(json_variant_unrefp) JsonVariant *array = NULL;
+        JsonVariant **elements = NULL;
+        size_t n_elements = 0;
         int r;
 
         assert(m);
         assert(ret);
+
+        CLEANUP_ARRAY(elements, n_elements, json_variant_unref_many);
 
         for (;;) {
                 const char *contents;
@@ -1754,28 +1757,31 @@ static int json_transform_dict_array(sd_bus_message *m, JsonVariant **ret) {
 
                 assert(type == 'e');
 
+                if (!GREEDY_REALLOC(elements, n_elements + 2))
+                        return log_oom();
+
                 r = sd_bus_message_enter_container(m, type, contents);
                 if (r < 0)
                         return bus_log_parse_error(r);
 
-                r = json_transform_and_append(m, &array);
+                r = json_transform_one(m, elements + n_elements);
                 if (r < 0)
                         return r;
 
-                r = json_transform_and_append(m, &array);
+                n_elements++;
+
+                r = json_transform_one(m, elements + n_elements);
                 if (r < 0)
                         return r;
+
+                n_elements++;
 
                 r = sd_bus_message_exit_container(m);
                 if (r < 0)
                         return bus_log_parse_error(r);
         }
 
-        if (!array)
-                return json_variant_new_array(ret, NULL, 0);
-
-        *ret = TAKE_PTR(array);
-        return 0;
+        return json_variant_new_object(ret, elements, n_elements);
 }
 
 static int json_transform_one(sd_bus_message *m, JsonVariant **ret) {


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/4118

Solution: Bring in the patch for json_transform_dict_array https://github.com/systemd/systemd/pull/28713

Testing: 
- Made changes to busctl.c
- build on the platform, upgrade to this version on platform with patch
- busctl --json=short get-property ccx.arinc429 /ccx/arinc429/Decoders ccx.Objects Names    
{"type":"a{ss}","data":{"i002":"Falcon_Decoder"}}

on ctest: 
```
ctest -> nightly_t009_wipe_all_system_data -i appliance
<appliance> t009_wipe_all_system_data:  STARTING 
<appliance> Loading test agent on system...
result {"type":"a{ss}","data":{"i2":"TestDeviceManager","i1":"Default Manager"}}

<appliance> t009_wipe_all_system_data: -> TestDeviceManager created!
result {"type":"a{ss}","data":{"i001":"admin","i003":"crew","i002":"user","i004":"TestUser"}}

<appliance> t009_wipe_all_system_data: -> TestUser created!
result {"type":"a{ss}","data":{"i01":"TestRoutingFirewall"}}

<appliance> t009_wipe_all_system_data: -> TestRoutingFirewall created!
result {"type":"a{ss}","data":{"i006":"TestLocalFirewall","i001":"Local SSH Access","i003":"VPN API Access","i002":"Local GUI Access","i005":"VPN GUI Access","i004":"VPN SSH Access","i007":"Local API Access","i011":"Local PBX Handsets","i009":"Local VPN Access","i008":"Local Key Access","i010":"Local NTP Server"}}

<appliance> t009_wipe_all_system_data: -> TestLocalFirewall created!

```